### PR TITLE
Reduce the amount of noise in the logs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,7 @@ class CountriesJsonUpdater
         'RUBYLIB' => nil,
         'NOKOGIRI_USE_SYSTEM_LIBRARIES' => '1'
       }
-      system(env, 'bundle install')
+      system(env, 'bundle install --quiet')
       system(env, 'bundle exec rake countries.json')
     end
   end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -68,7 +68,7 @@ describe CountriesJsonUpdater do
           { branch: 'asdf', message: 'Refresh countries.json' }
         ]
       )
-      system.expect(:call, nil, [Hash, 'bundle install'])
+      system.expect(:call, nil, [Hash, 'bundle install --quiet'])
       system.expect(:call, nil, [Hash, 'bundle exec rake countries.json'])
     end
 


### PR DESCRIPTION
It can be hard to see what's going on in the logs when there are lots of
lines of output from bundle install. These lines don't tell us anything
particularly useful so silence them so we don't miss any actual errors.
