### PR TITLE
Speed up bundle install step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 /coverage/
+.bundle

--- a/app.rb
+++ b/app.rb
@@ -39,7 +39,7 @@ class CountriesJsonUpdater
         'RUBYLIB' => nil,
         'NOKOGIRI_USE_SYSTEM_LIBRARIES' => '1'
       }
-      system(env, 'bundle install --quiet')
+      system(env, 'bundle install --quiet --jobs 4 --without test')
       system(env, 'bundle exec rake countries.json')
     end
   end

--- a/test/app_test.rb
+++ b/test/app_test.rb
@@ -68,7 +68,7 @@ describe CountriesJsonUpdater do
           { branch: 'asdf', message: 'Refresh countries.json' }
         ]
       )
-      system.expect(:call, nil, [Hash, 'bundle install --quiet'])
+      system.expect(:call, nil, [Hash, 'bundle install --quiet --jobs 4 --without test'])
       system.expect(:call, nil, [Hash, 'bundle exec rake countries.json'])
     end
 


### PR DESCRIPTION
This adds a couple of extra flags to `bundle install` to speed up the
install step slightly. One is --jobs, which runs the install in
parallel. The other is `--without test`, which skips installing any test
dependencies.

Fixes #3 
