### PR TITLE
Don't re-queue branches that are already in the queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ before_install: gem install bundler -v 1.10.6
 env:
   global:
     - EVERYPOLITICIAN_DATA_REPO=everypolitician/everypolitician-data
+services:
+  - redis-server


### PR DESCRIPTION
If there's already a job in the queue for a branch then there's no point
in adding it to the queue again. So instead we print out a warning and
bail out before creating another job.

Fixes #5 
